### PR TITLE
add support for SVector backing

### DIFF
--- a/src/FourVectors.jl
+++ b/src/FourVectors.jl
@@ -5,7 +5,7 @@ using StaticArrays
 using LinearAlgebra
 
 export FourVector
-export Particle
+export Particle, SParticle
 
 export psq, invmasssq, mass
 export sphericalangles, boostfactor

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -45,15 +45,15 @@ function Base.getproperty(p::FourVector, sym::Symbol)
     (sym == :Pz || sym == :pz || sym == :z || sym == :Z) && return getfield(p, :fv)[3]
     (sym == :E  || sym == :p0 || sym == :t || sym == :T) && return getfield(p, :fv)[4]
     (sym == :p  || sym == :P) && return _view(getfield(p, :fv), SOneTo(3))
-    error("type FourVector has no property $(sym)")
+    throw(ArgumentError("type FourVector has no property $(sym)"))
 end
 
-LinearAlgebra.dot(p1::FourVector, p2::FourVector) = p1.E * p2.E - dot(p1.p, p2.p)
+LinearAlgebra.dot(p1::FourVector, p2::FourVector) = p1.E * p2.E - dot(p1.P, p2.P)
 
 # properties
-psq(p::FourVector) = sum(abs2, p.p)
+psq(p::FourVector) = sum(abs2, p.P)
 invmasssq(p::FourVector) = p ⋅ p
 mass(p::FourVector) = sqrt(invmasssq(p))
 
-sphericalangles(p::FourVector) = p.p[3] / norm(p.p), atan(p.p[2], p.p[1])
+sphericalangles(p::FourVector) = p.P[3] / norm(p.P), atan(p.P[2], p.P[1])
 boostfactor(p::FourVector) = p.E / mass(p)

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -1,52 +1,59 @@
-
-struct FourVector{T} <: AbstractVector{Int}
-    fv::MVector{4,T} # px,py,pz,E
+struct FourVector{T, A <: StaticVector{4, T}} <: StaticVector{4, T}
+    fv::A # px,py,pz,E
+    FourVector(fv::A) where {T, A <: StaticVector{4, T}} = new{T, A}(fv)
 end
-FourVector(x,y,z; t) = FourVector(MVector(x,y,z,t))
-Particle(;E,p) = FourVector(p...; t=E)
-# 
-function Particle(px,py,pz; E=-Inf, msq = -Inf)
-    (msq == -Inf) && (E == -Inf) && error("give either msq of E")
-    (E != -Inf) && return FourVector(px,py,pz,t=E)
-    return FourVector(px,py,pz;t=sqrt(px^2+py^2+pz^2+msq))
+FourVector{T, A}(x::Tuple) where {T, A} = FourVector(A(x))
+FourVector(x, y, z; t) = FourVector(MVector(x, y, z, t))
+Particle(; E, p) = FourVector(p...; t=E)
+SParticle(; E, p) = FourVector(SVector(p..., E))
+
+function Particle(px,py,pz; E=nothing, msq=nothing)
+    if (msq === nothing) == (E === nothing)
+        throw(ArgumentError("Must provide exactly one of either `msq` or `E`."))
+    end
+    E !== nothing && return FourVector(px, py, pz; t=E)
+    return FourVector(px, py, pz; t=sqrt(hypot(px, py, pz)^2 + msq))
+end
+function SParticle(px,py,pz; E=nothing, msq=nothing)
+    if (msq === nothing) == (E === nothing)
+        throw(ArgumentError("Must provide exactly one of either `msq` or `E`."))
+    end
+    E !== nothing && return FourVector(SVector(px, py, pz, E))
+    return FourVector(SVector(px, py, pz, sqrt(hypot(px, py, pz)^2 + msq)))
 end
 
-import Base:size
-size(p::FourVector{T} where T) = (4,)
+function StaticArrays.similar_type(
+    ::Type{FourVector{S, A}}, ::Type{T}, ::Size{(4,)},
+) where {S, A, T}
+    return FourVector{T, similar_type(A, T)}
+end
 
-import Base: getindex, setindex!
-getindex(p::FourVector{T} where T, i::Int) = (i==0 ? getindex(p.fv,4) : getindex(p.fv,i))
-getindex(p::FourVector{T} where T, I::Vararg) = getindex(p.fv, I...)
-# setindex!(p::FourVector{T} where T, v, i::Int)	= (i==0 ? setindex!(p.fv,v,4) : setindex!(p.fv, v, i))
-setindex!(p::FourVector{T} where T, v, I::Vararg{Int, 1}) = setindex!(p.fv, v, I...)
+Base.@propagate_inbounds function Base.getindex(p::FourVector, i::Int)
+    return getindex(p.fv, i == 0 ? 4 : i)
+end
+Base.@propagate_inbounds function Base.setindex!(p::FourVector, v, i::Int)
+    return setindex!(p.fv, v, i == 0 ? 4 : i)
+end
 
-import Base:+,-,*
-+(p1::FourVector, p2::FourVector) = FourVector(p1.fv+p2.fv)
-*(p::FourVector, α::T where T<:Number) = FourVector(p.fv*α)
-*(α::T where T<:Number, p::FourVector) = FourVector(p.fv*α)
--(p1::FourVector, p2::FourVector) = FourVector(p1.fv-p2.fv)
+_view(x::MVector, i) = view(x, i)
+_view(x::StaticVector, i) = x[i]
 
-import Base:copy
-copy(p::FourVector) = FourVector(copy(p.fv))
-
-import Base:getproperty
-function getproperty(p::FourVector, sym::Symbol)
+function Base.getproperty(p::FourVector, sym::Symbol)
     (sym in fieldnames(FourVector)) && return getfield(p, sym)
     (sym == :Px || sym == :px || sym == :x || sym == :X) && return getfield(p, :fv)[1]
     (sym == :Py || sym == :py || sym == :y || sym == :Y) && return getfield(p, :fv)[2]
     (sym == :Pz || sym == :pz || sym == :z || sym == :Z) && return getfield(p, :fv)[3]
     (sym == :E  || sym == :p0 || sym == :t || sym == :T) && return getfield(p, :fv)[4]
-    (sym == :p  || sym == :P) && return @view getfield(p, :fv)[1:3]
-    error("no property $(sym)")
+    (sym == :p  || sym == :P) && return _view(getfield(p, :fv), SOneTo(3))
+    error("type FourVector has no property $(sym)")
 end
 
-import LinearAlgebra: dot
-dot(p1::FourVector, p2::FourVector) = p1.E*p2.E - dot(p1.p,p2.p)
+LinearAlgebra.dot(p1::FourVector, p2::FourVector) = p1.E * p2.E - dot(p1.p, p2.p)
 
 # properties
-psq(p::FourVector) = sum(abs2,p.p)
-invmasssq(p::FourVector) = p⋅p
+psq(p::FourVector) = sum(abs2, p.p)
+invmasssq(p::FourVector) = p ⋅ p
 mass(p::FourVector) = sqrt(invmasssq(p))
 
-sphericalangles(p::FourVector) = p.p[3]/norm(p.p), atan(p.p[2],p.p[1])
-boostfactor(p::FourVector) = p.E/mass(p)
+sphericalangles(p::FourVector) = p.p[3] / norm(p.p), atan(p.p[2], p.p[1])
+boostfactor(p::FourVector) = p.E / mass(p)

--- a/test/creation.jl
+++ b/test/creation.jl
@@ -8,6 +8,9 @@ using Test
 @testset "creation - $Particle" for Particle in [Particle, SParticle]
     @test Particle(0,0,3; msq=4^2) == Particle(p=[0,0,3], E=5.0)
 
+    @test_throws ArgumentError Particle(1,2,3)
+    @test_throws ArgumentError Particle(1,2,3; msq=4^2, E=3.3)
+
     @test mass(Particle(1,2,3; msq=4)) ≈ 2
 
     @test collect(FourVector(1,2,3; t=4)) == [1,2,3,4]
@@ -26,6 +29,8 @@ using Test
     @test x.Px == x.X == x.x == x.px
     @test x.Py == x.Y == x.y == x.py
     @test x.Pz == x.Z == x.z == x.pz
+    @test psq(x) == sum(abs2, x[1:3])
+    @test_throws ArgumentError x.SomethingElse
 
     @test length(x) == 4
     @test mass(x * 1000) ≈ 1000*mass(x)

--- a/test/creation.jl
+++ b/test/creation.jl
@@ -4,28 +4,38 @@ using Test
 
 @test FourVector(1,2,3; t=4) == FourVector(MVector(1,2,3,4.0))
 @test FourVector(1,2,3; t=4) == Particle(p=[1,2,3], E=4.0)
-@test Particle(0,0,3; msq=4^2) == Particle(p=[0,0,3], E=5.0)
-# 
-@test mass(Particle(1,2,3; msq=4)) ≈ 2
 
-@test collect(FourVector(1,2,3; t=4)) == [1,2,3,4]
+@testset "creation - $Particle" for Particle in [Particle, SParticle]
+    @test Particle(0,0,3; msq=4^2) == Particle(p=[0,0,3], E=5.0)
 
-x = Particle(1.1,2.2,3.0; msq=4)
-newp = [1.1,1.1,1.1] 
-x.p .= newp
-@test invmasssq(x) == x.E^2 - sum(abs2,newp)
+    @test mass(Particle(1,2,3; msq=4)) ≈ 2
 
-@test x.E == x.T == x[0]== x[4]
-@test x.Px == x.X == x.x == x.px
-@test x.Py == x.Y == x.y == x.py
-@test x.Pz == x.Z == x.z == x.pz
+    @test collect(FourVector(1,2,3; t=4)) == [1,2,3,4]
 
-@test length(x) == 4
-@test mass(x * 1000) ≈ 1000*mass(x)
+    x = Particle(1.1,2.2,3.0; msq=4)
 
-@test sphericalangles(Particle(0,4,3; msq=4^2)) == (3/5,π/2)
-@test boostfactor(Particle(4,0,0; msq=3^2)) == 5/3
+    newp = [1.1,1.1,1.1]
+    if x isa FourVector{Float64, <:MVector}
+        x.p .= newp
+    else
+        x = Particle(1.1, 1.1, 1.1; msq=4)
+    end
+    @test invmasssq(x) == x.E^2 - sum(abs2,newp)
 
-x1,x2 = x[[1,2]]
-x[[1,2]] .= x[[2,1]]
-@test x[[1,2]] == [x2,x1]
+    @test x.E == x.T == x[0] == x[4]
+    @test x.Px == x.X == x.x == x.px
+    @test x.Py == x.Y == x.y == x.py
+    @test x.Pz == x.Z == x.z == x.pz
+
+    @test length(x) == 4
+    @test mass(x * 1000) ≈ 1000*mass(x)
+
+    @test sphericalangles(Particle(0,4,3; msq=4^2)) == (3/5,π/2)
+    @test boostfactor(Particle(4,0,0; msq=3^2)) == 5/3
+
+    if x isa FourVector{Float64, <:MVector}
+        x1,x2 = x[[1,2]]
+        x[[1,2]] .= x[[2,1]]
+        @test x[[1,2]] == [x2,x1]
+    end
+end


### PR DESCRIPTION
This allows for arbitrary statically sized arrays as backing for `FourVector`. I hope you don't mind, I also refactored the constructors and some of the functions a bit. `FourVector` now also subtypes `StaticVector`, which allows us to just make use of the existing broadcasting machinery and we don't have to overload `+`, for example.