### PR TITLE
Fix broken links and add link checking

### DIFF
--- a/.github/workflows/LinkCheck.yml
+++ b/.github/workflows/LinkCheck.yml
@@ -16,6 +16,27 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
+            - uses: julia-actions/setup-julia@v3
+              with:
+                  version: "1"
+                  arch: x64
+            - uses: julia-actions/cache@v3
+            - name: Generate Literate tutorials
+              run: |
+                  julia --project=docs -e '
+                  import Pkg
+                  Pkg.instantiate()
+                  using Literate
+                  mkpath("docs/src/tutorials")
+                  Literate.markdown(
+                      "literate/tutorials/pi0_decay.jl",
+                      "docs/src/tutorials";
+                      name = "pi0_decay",
+                      credit = false,
+                      documenter = true,
+                      execute = false,
+                  )
+                  '
             - name: Check links
               uses: lycheeverse/lychee-action@v2
               with:

--- a/.github/workflows/LinkCheck.yml
+++ b/.github/workflows/LinkCheck.yml
@@ -1,0 +1,25 @@
+name: Link Check
+
+on:
+    push:
+        branches:
+            - main
+    pull_request:
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+jobs:
+    lychee:
+        name: lychee
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+            - name: Check links
+              uses: lycheeverse/lychee-action@v2
+              with:
+                  fail: true
+                  args: --no-progress './**/*.md' './**/*.html'
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/LinkCheck.yml
+++ b/.github/workflows/LinkCheck.yml
@@ -16,27 +16,6 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
-            - uses: julia-actions/setup-julia@v3
-              with:
-                  version: "1"
-                  arch: x64
-            - uses: julia-actions/cache@v3
-            - name: Generate Literate tutorials
-              run: |
-                  julia --project=docs -e '
-                  import Pkg
-                  Pkg.instantiate()
-                  using Literate
-                  mkpath("docs/src/tutorials")
-                  Literate.markdown(
-                      "literate/tutorials/pi0_decay.jl",
-                      "docs/src/tutorials";
-                      name = "pi0_decay",
-                      credit = false,
-                      documenter = true,
-                      execute = false,
-                  )
-                  '
             - name: Check links
               uses: lycheeverse/lychee-action@v2
               with:

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,2 @@
+# Link-checked by Documenter during docs/make.jl (after Literate generates tutorials).
+docs/src/

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Coverage](https://codecov.io/gh/mmikhasenko/FourVectors.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/mmikhasenko/FourVectors.jl)
 [![Docs](https://img.shields.io/badge/docs-blue.svg)](https://mmikhasenko.github.io/FourVectors.jl/dev/)
 
-FourVectors.jl provides an immutable [`FieldVector{4,T}`](https://juliaarrays.github.io/StaticArrays.jl/stable/pages/api/#StaticArrays.FieldVector) type `FourVector` (components `px`, `py`, `pz`, `E` in Cartesian coordinates).
+FourVectors.jl provides an immutable [`FieldVector{4,T}`](https://juliaarrays.github.io/StaticArrays.jl/stable/api/#StaticArraysCore.FieldVector) type `FourVector` (components `px`, `py`, `pz`, `E` in Cartesian coordinates).
 
 It plugs into **[LorentzVectorBase.jl](https://github.com/JuliaHEP/LorentzVectorBase.jl)** for kinematic accessors. Subtyping `FieldVector` yields `AbstractVector`/`AbstractArray` behavior: indexing (`p[1:3]`), iteration, broadcasting, etc.
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -28,6 +28,11 @@ makedocs(;
     authors = "Misha Mikhasenko and contributors.",
     format = Documenter.HTML(; prettyurls = get(ENV, "CI", "false") == "true"),
     modules = [FourVectors],
+    linkcheck = true,
+    linkcheck_ignore = [
+        # GitHub blob URLs rate-limit anonymous curl requests during linkcheck.
+        r"^https://github.com/mmikhasenko/FourVectors.jl/blob/",
+    ],
     pages = [
         "Home" => "index.md",
         "Tutorials" =>


### PR DESCRIPTION
## Summary
- Fix the StaticArrays `FieldVector` link in README (`stable/api/#StaticArraysCore.FieldVector`).
- Enable Documenter `linkcheck` during docs builds (with an ignore for GitHub blob URLs that rate-limit anonymous curl).
- Add a `LinkCheck` CI workflow using lychee to scan markdown and HTML for broken external links.

## Test plan
- [x] `Link Check` workflow passes on this PR
- [x] `Documentation` workflow passes with `linkcheck = true`
- [x] README docs badge and tutorial links resolve at https://mmikhasenko.github.io/FourVectors.jl/dev/


Made with [Cursor](https://cursor.com)