### PR TITLE
Add HEP tutorials for four-vector basics and transformations

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -6,7 +6,7 @@ JuliaMinVersion: "1.3"
 License: MIT
 LicenseCopyrightHolders: Mikhail Mikhasenko
 PackageName: FourVectors
-PackageOwner: mmikhasenko
+PackageOwner: JuliaHEP
 PackageUUID: b122eb78-8380-428a-b8c8-584a022ae8b6
 _commit: v0.10.1
 _src_path: https://github.com/JuliaBesties/BestieTemplate.jl

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,8 @@ StaticArrays = "1"
 julia = "1.7"
 
 [extras]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["LinearAlgebra", "Test"]

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ julia> ] add https://github.com/mmikhasenko/FourVectors.jl
 
 ## Documentation
 
-Full API reference and a worked example (neutral pion decay) are on the [Documenter site](https://mmikhasenko.github.io/FourVectors.jl/dev/).
+Full API reference and tutorials are on the [Documenter site](https://mmikhasenko.github.io/FourVectors.jl/dev/).
 
-The tutorial is written as plain Julia in `literate/tutorials/pi0_decay.jl` and woven into the manual with Literate.jl when the docs build runs `docs/make.jl`.
+Tutorials are plain Julia scripts in `literate/tutorials/` and woven into the manual with Literate.jl when the docs build runs `docs/make.jl`.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # FourVectors
 
-[![Test workflow status](https://github.com/mmikhasenko/FourVectors.jl/actions/workflows/Test.yml/badge.svg?branch=main)](https://github.com/mmikhasenko/FourVectors.jl/actions/workflows/Test.yml?query=branch%3Amain)
-[![Coverage](https://codecov.io/gh/mmikhasenko/FourVectors.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/mmikhasenko/FourVectors.jl)
-[![Docs](https://img.shields.io/badge/docs-blue.svg)](https://mmikhasenko.github.io/FourVectors.jl/dev/)
+[![Test workflow status](https://github.com/JuliaHEP/FourVectors.jl/actions/workflows/Test.yml/badge.svg?branch=main)](https://github.com/JuliaHEP/FourVectors.jl/actions/workflows/Test.yml?query=branch%3Amain)
+[![Coverage](https://codecov.io/gh/JuliaHEP/FourVectors.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/JuliaHEP/FourVectors.jl)
+[![Docs](https://img.shields.io/badge/docs-blue.svg)](https://juliahep.github.io/FourVectors.jl/dev/)
 
 FourVectors.jl is a small package for Cartesian four-momenta in high-energy physics.
 The central type is `FourVector`, an immutable `FieldVector{4}` from StaticArrays with named components `px`, `py`, `pz`, and `E`.
@@ -27,12 +27,12 @@ The package is not registered yet.
 Install from GitHub:
 
 ```julia
-julia> ] add https://github.com/mmikhasenko/FourVectors.jl
+julia> ] add https://github.com/JuliaHEP/FourVectors.jl
 ```
 
 ## Documentation
 
-Full API reference and tutorials are on the [Documenter site](https://mmikhasenko.github.io/FourVectors.jl/dev/).
+Full API reference and tutorials are on the [Documenter site](https://juliahep.github.io/FourVectors.jl/dev/).
 
 Tutorials are plain Julia scripts in `literate/tutorials/` and woven into the manual with Literate.jl when the docs build runs `docs/make.jl`.
 

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.11.5"
 manifest_format = "2.0"
-project_hash = "cabddee8cef47b48f1e2b2d5b124048074e36825"
+project_hash = "3d5cd1b457e2c55568ed89dad347e5eb648368fd"
 
 [[deps.ANSIColoredPrinters]]
 git-tree-sha1 = "574baf8110975760d391c710b6341da1afa48d8c"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,8 +2,10 @@
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 FourVectors = "b122eb78-8380-428a-b8c8-584a022ae8b6"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
+LorentzVectorBase = "592a752d-6533-4762-a71b-738712ea30ec"
 
 [compat]
 Documenter = "1"
 Literate = "2"
+LorentzVectorBase = "0.1"
 julia = "1.7"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -40,7 +40,7 @@ makedocs(;
     linkcheck = true,
     linkcheck_ignore = [
         # GitHub blob URLs rate-limit anonymous curl requests during linkcheck.
-        r"^https://github.com/mmikhasenko/FourVectors.jl/blob/",
+        r"^https://github.com/JuliaHEP/FourVectors.jl/blob/",
     ],
     pages = [
         "Home" => "index.md",
@@ -50,7 +50,7 @@ makedocs(;
 )
 
 deploydocs(;
-    repo = "github.com/mmikhasenko/FourVectors.jl.git",
+    repo = "github.com/JuliaHEP/FourVectors.jl.git",
     devbranch = "main",
     versions = ["dev" => "dev"],
 )

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -14,14 +14,23 @@ const GENERATED_MD = joinpath(@__DIR__, "src", "tutorials")
 
 mkpath(GENERATED_MD)
 
-Literate.markdown(
-    joinpath(LITERATE_SRC, "pi0_decay.jl"),
-    GENERATED_MD;
-    name = "pi0_decay",
-    credit = false,
-    documenter = true,
-    execute = true,
-)
+const TUTORIAL_PAGES = [
+    "Creating and accessing" => "creation_and_access",
+    "Algebra" => "algebra",
+    "Transformations" => "transformations",
+    "Neutral pion decay" => "pi0_decay",
+]
+
+for (_, name) in TUTORIAL_PAGES
+    Literate.markdown(
+        joinpath(LITERATE_SRC, "$(name).jl"),
+        GENERATED_MD;
+        name,
+        credit = false,
+        documenter = true,
+        execute = true,
+    )
+end
 
 makedocs(;
     sitename = "FourVectors.jl",
@@ -35,8 +44,7 @@ makedocs(;
     ],
     pages = [
         "Home" => "index.md",
-        "Tutorials" =>
-            ["Neutral pion decay" => joinpath("tutorials", "pi0_decay.md")],
+        "Tutorials" => [title => joinpath("tutorials", "$name.md") for (title, name) in TUTORIAL_PAGES],
         "API reference" => "reference.md",
     ],
 )

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,9 +4,13 @@
 
 Installation, exported kinematic accessors, and usage examples appear in the README on GitHub (`README.md`).
 
-## Guides
+## Tutorials
 
-See [Neutral pion decay](tutorials/pi0_decay.md).
+Step-by-step guides (executed when the manual is built):
 
-Source Julia script: [`literate/tutorials/pi0_decay.jl`](https://github.com/mmikhasenko/FourVectors.jl/blob/main/literate/tutorials/pi0_decay.jl).
-It is bundled into this manual with **[Literate.jl](https://github.com/fredrikekre/Literate.jl)** and its code chunks are executed during **`docs/make.jl`** when the manual is built.
+1. [Creating and accessing](tutorials/creation_and_access.md) — construction, fields, indexing, accessors and aliases
+2. [Algebra](tutorials/algebra.md) — `+`, `-`, scalar `*`, Minkowski `dot`
+3. [Transformations](tutorials/transformations.md) — rotations, boosts, `rotate_to_plane`, `transform_to_cmf`
+4. [Neutral pion decay](tutorials/pi0_decay.md) — worked decay example combining the above
+
+Sources live under [`literate/tutorials/`](https://github.com/mmikhasenko/FourVectors.jl/tree/main/literate/tutorials/) and are woven into this manual with **[Literate.jl](https://github.com/fredrikekre/Literate.jl)** during **`docs/make.jl`**.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,6 +1,6 @@
 # FourVectors.jl
 
-[FourVectors](https://github.com/mmikhasenko/FourVectors.jl) wraps an immutable Cartesian four-momentum (**`FourVector`** as **`FieldVector{4}`**) and implements the **[LorentzVectorBase.jl](https://github.com/JuliaHEP/LorentzVectorBase.jl)** interface.
+[FourVectors](https://github.com/JuliaHEP/FourVectors.jl) wraps an immutable Cartesian four-momentum (**`FourVector`** as **`FieldVector{4}`**) and implements the **[LorentzVectorBase.jl](https://github.com/JuliaHEP/LorentzVectorBase.jl)** interface.
 
 Installation, exported kinematic accessors, and usage examples appear in the README on GitHub (`README.md`).
 
@@ -13,4 +13,4 @@ Step-by-step guides (executed when the manual is built):
 3. [Transformations](tutorials/transformations.md) — rotations, boosts, `rotate_to_plane`, `transform_to_cmf`
 4. [Neutral pion decay](tutorials/pi0_decay.md) — worked decay example combining the above
 
-Sources live under [`literate/tutorials/`](https://github.com/mmikhasenko/FourVectors.jl/tree/main/literate/tutorials/) and are woven into this manual with **[Literate.jl](https://github.com/fredrikekre/Literate.jl)** during **`docs/make.jl`**.
+Sources live under [`literate/tutorials/`](https://github.com/JuliaHEP/FourVectors.jl/tree/main/literate/tutorials/) and are woven into this manual with **[Literate.jl](https://github.com/fredrikekre/Literate.jl)** during **`docs/make.jl`**.

--- a/literate/tutorials/algebra.jl
+++ b/literate/tutorials/algebra.jl
@@ -10,7 +10,7 @@ using FourVectors
 using LinearAlgebra
 using Test
 
-p = FourVector(10.0, 0.0, 0.0; E = 11.0)   # nearly collinear with +z
+p = FourVector(10.0, 0.0, 0.0; E = 11.0)   # nearly collinear with +x
 q = FourVector(-3.0, 1.0, 2.0; M = 2.0)    # on-shell particle of mass 2
 
 # ## Addition and subtraction

--- a/literate/tutorials/algebra.jl
+++ b/literate/tutorials/algebra.jl
@@ -1,0 +1,65 @@
+# # Algebra of four-vectors
+#
+# Four-momentum is conserved as a **four-vector**, not as separate sums of energy and three-momentum in an arbitrary frame.
+# Because **`FourVector`** subtypes **`FieldVector{4}`**, Julia’s `+`, `-`, and scalar `*` act component-wise —
+# exactly what you need for building total momenta, decay kinematics, and linear combinations in matrix elements.
+#
+# The Minkowski inner product (invariant scalar product) is **`dot`**, with the same $(+,-,-,-)$ signature as the mass formula.
+
+using FourVectors
+using LinearAlgebra
+using Test
+
+p = FourVector(10.0, 0.0, 0.0; E = 11.0)   # nearly collinear with +z
+q = FourVector(-3.0, 1.0, 2.0; M = 2.0)    # on-shell particle of mass 2
+
+# ## Addition and subtraction
+#
+# **`p + q`** adds each component: $(p+q)^\mu = p^\mu + q^\mu$.
+# In a decay or splitting $P \to p_1 + p_2 + \cdots$, momentum conservation reads $\sum_i p_i^\mu = P^\mu$.
+#
+# **Important:** $m(P) \neq m(p_1) + m(p_2)$ in general.
+# Only the **invariant** $m^2 = p\cdot p$ is computed from the full four-vector; adding masses is not meaningful physics.
+
+sum_pq = p + q
+diff_pq = p - q
+
+@test sum_pq.px ≈ p.px + q.px
+@test sum_pq.E ≈ p.E + q.E
+@test diff_pq ≈ p - q
+@test (p - q) + q ≈ p
+
+# Typical pattern: one daughter is reconstructed, the other is inferred by subtraction in the **same frame**:
+
+parent = FourVector(1.0, 1.0, 30.0; M = 0.135)   # e.g. π⁰ in GeV
+daughter = FourVector(0.2, 0.1, 5.0; E = 5.01)   # photon or track candidate
+other = parent - daughter
+
+@test parent ≈ daughter + other
+
+# Here `other` is the four-momentum of the complementary system; it is on-shell only if `daughter` was exact.
+
+# ## Scalar multiplication
+#
+# Multiplying by a real number scales **all** components.
+# A common trick for massless particles is to start from a light-like direction $(\hat{n}, 1)$ in arbitrary units
+# and multiply by an energy scale so that $m^2 \approx 0$ after boosts (see the π⁰ decay tutorial).
+
+scaled = 0.5 * parent
+@test scaled.px ≈ 0.5 * parent.px
+@test scaled.E ≈ 0.5 * parent.E
+@test parent * 2 ≈ 2 * parent
+
+# ## Minkowski inner product
+#
+# **`dot(p, q) = E_1 E_2 - \vec{p}_1\cdot\vec{p}_2`** (ordinary Euclidean dot for the spatial parts).
+# For one four-vector, **`dot(p, p) = m^2(p)`** — this is the on-shell condition checker.
+#
+# The product is **Lorentz invariant**: the same number in every inertial frame, unlike $E$ or $p_z$ alone.
+
+@test dot(p, p) ≈ mass2(p)
+@test dot(p, q) ≈ p.E * q.E - (p.px * q.px + p.py * q.py + p.pz * q.pz)
+
+# Illustration: reconstructing the parent mass from a sum of daughters only works when the daughters sum to the parent four-vector.
+
+(mass(parent), mass(daughter + other), dot(parent, parent), scaled.E)

--- a/literate/tutorials/creation_and_access.jl
+++ b/literate/tutorials/creation_and_access.jl
@@ -1,0 +1,90 @@
+# # Creating and accessing four-vectors
+#
+# In collider and fixed-target analyses we routinely work with four-momenta
+# $p^\mu = (p_x, p_y, p_z, E)$ in Cartesian form.
+# **FourVectors.jl** stores them as an immutable **`FourVector`** with metric signature $(+,-,-,-)$,
+# so the invariant mass squared is $m^2 = E^2 - \vec{p}^{\,2}$.
+#
+# This tutorial shows how to build on-shell momenta, read components, and extract standard HEP kinematics.
+
+using FourVectors
+using LorentzVectorBase
+using Test
+
+# ## Construction: energy *or* invariant mass
+#
+# You specify the spatial momentum $(p_x, p_y, p_z)$ and **exactly one** timelike quantity:
+#
+# - **`E`**: energy (use when it is known from reconstruction or simulation), or
+# - **`M`**: invariant mass (use when the particle species is identified — the package sets $E = \sqrt{|\vec{p}|^2 + M^2}$).
+#
+# Supplying both or neither is an error: the four-vector must be on-shell for a single particle.
+
+p_E = FourVector(1.0, 2.0, 3.0; E = 4.0)   # GeV-style numbers; units are your convention
+p_M = FourVector(1.0, 2.0, 3.0; M = √2)    # same kinematics, mass fixes E
+
+@test p_E ≈ p_M
+@test_throws ArgumentError FourVector(1, 2, 3)
+@test_throws ArgumentError FourVector(1.0, 2.0, 3.0; E = 3.0, M = 1.0)
+
+# Integer literals promote to floating point when combined with `E` or `M` (common in generator-level ntuples).
+
+p_promoted = FourVector(1, 2, 3; E = 4.0)
+@test p_promoted isa FourVector{Float64}
+
+# A tuple or length-4 vector is accepted; component order is always **`(px, py, pz, E)`** (not $(E,\vec{p})$).
+
+p_tuple = FourVector((1.0, 2.0, 3.0, 4.0))
+@test p_tuple ≈ p_E
+
+# ## Lab-frame components: names and indices
+#
+# The type behaves like a small Julia vector: named fields match the physics labels,
+# and integer indices follow the same $(p_x, p_y, p_z, E)$ ordering.
+
+@test p_E.px == p_E[1] == 1.0
+@test p_E.py == p_E[2] == 2.0
+@test p_E.pz == p_E[3] == 3.0
+@test p_E.E == p_E[4] == 4.0
+
+# The spatial three-momentum $\vec{p} = (p_x, p_y, p_z)$ is available as a slice (no extra wrapper type).
+
+@test p_E[1:3] == [p_E.px, p_E.py, p_E.pz]
+
+# ## Kinematic scalars (exported accessors)
+#
+# After `using FourVectors`, standard LorentzVectorBase quantities are re-exported.
+# Below, $|\vec{p}| = \sqrt{p_x^2 + p_y^2 + p_z^2}$ and $p_\mathrm{T} = \sqrt{p_x^2 + p_y^2}$.
+
+@test mass(p_E) ≈ √2
+@test transverse_momentum(p_E) == √(1.0^2 + 2.0^2)
+@test spatial_magnitude(p_E) ≈ √14
+@test polar_angle(p_E) ≈ acos(3 / √14)      # θ w.r.t. +z
+@test azimuthal_angle(p_E) ≈ atan(2, 1)     # φ in the transverse plane
+@test cos_theta(p_E) ≈ 3 / √14
+
+# Rapidity and pseudorapidity are available the same way (`rapidity`, `pseudorapidity`) when needed for boosts along $z$.
+
+# ## Shorter names (`pt`, `φ`, `η`, …)
+#
+# LorentzVectorBase also defines analysis-friendly aliases (`pt`, `phi`, `eta`, …).
+# They are **not** re-exported from FourVectors; qualify the module or import what you need:
+
+@test LorentzVectorBase.pt(p_E) ≈ transverse_momentum(p_E)
+@test LorentzVectorBase.phi(p_E) ≈ azimuthal_angle(p_E)
+@test LorentzVectorBase.eta(p_E) ≈ pseudorapidity(p_E)
+
+# ## Direction as a named tuple
+#
+# **`spherical_coordinates`** packages the polar direction of $\vec{p}$ as `(cosθ, ϕ)`,
+# matching $\cos\theta = p_z / |\vec{p}|$ and $\phi = \mathrm{atan}(p_y, p_x)$.
+# This is convenient when chaining rotations (see the transformations tutorial).
+
+Ω = spherical_coordinates(p_E)
+@test Ω.cosθ ≈ cos_theta(p_E)
+@test Ω.ϕ ≈ azimuthal_angle(p_E)
+@test propertynames(Ω) === (:cosθ, :ϕ)
+
+# Summary of the example four-vector:
+
+(collect(p_E), mass(p_E), LorentzVectorBase.pt(p_E), Ω)

--- a/literate/tutorials/pi0_decay.jl
+++ b/literate/tutorials/pi0_decay.jl
@@ -1,21 +1,34 @@
 # # π⁰ → γ γ in the laboratory
 #
-# This tutorial walks through a minimal four-momentum exercise for neutral pion decay.
-# Photon energies match half the π⁰ mass in the decay frame (`m_pi0/2`), boosted with **`Bz`** into the lab, rotated with **`Ry`** and **`Rz`** so that photon 1 aligns with the parent kinematics (**`spherical_coordinates`**), and complemented by subtraction for photon 2.
+# A compact end-to-end example that combines construction, algebra, and transformations.
+# We model $\pi^0 \to \gamma\gamma$ in the lab: the parent pion has mass $m_{\pi^0}$ and a finite lab momentum;
+# each photon is massless ($m_\gamma = 0$).
+#
+# Strategy:
+#
+# 1. Build photon 1 in a frame where its direction is simple, with a **light-like proxy** scaled to energy $m_{\pi^0}/2$ in the π⁰ rest frame.
+# 2. **Boost** to the lab with **`Bz(boost_gamma(p_pi0))`**.
+# 3. **Rotate** with **`Ry`** and **`Rz`** so the kinematics align with the parent’s polar axis (**`spherical_coordinates`**).
+# 4. Obtain photon 2 by **four-momentum subtraction** — momentum conservation in the lab.
 
 using FourVectors
 using Test
 
-# ## Mass units and laboratory pion
+# ## Parent pion in the lab
 #
-# Approximate π⁰ mass in GeV; lab three-momentum is chosen as a simple illustrative example.
+# Mass in GeV (PDG value is $\approx 135\,\mathrm{MeV}$); spatial components are illustrative lab momentum.
 
 m_pi0 = 0.135
 p_pi0 = FourVector(1.0, 1.0, 30.0; M = m_pi0)
 
-# ## Photon 1 — scale (massless proxy), lab boost, rotations to match the parent axis
+# ## Photon 1: decay frame → lab → parent axis
 #
-# Pick polar angle `theta_gamma` along `(sin θ, 0, cos θ)`. The factor `m_pi0/2` sets the invariant mass squared to zero for the auxiliary `FourVector`; then apply **`Bz(boost_gamma(p_pi0))`** and rotations using `acos(Omega.cosθ)` and **`Omega.ϕ`** where `Omega = spherical_coordinates(p_pi0)` encodes the pion pointing direction.
+# In the π⁰ rest frame the two photons are back-to-back with energy $E_\gamma = m_{\pi^0}/2$.
+# We start from a unit direction $(\sin\theta_\gamma, 0, \cos\theta_\gamma)$ with $E=1$, then multiply by $m_{\pi^0}/2$
+# so that $m^2 = E^2 - |\vec{p}|^2 \approx 0$ for this proxy four-vector.
+#
+# **`Bz(boost_gamma(p_pi0))`** takes the configuration to the lab frame along the pion’s boost.
+# **`Ry(acos(Ω.cosθ))`** and **`Rz(Ω.ϕ)`** with `Ω = spherical_coordinates(p_pi0)` align the decay plane with the parent direction.
 
 theta_gamma = 0.3
 Omega = spherical_coordinates(p_pi0)
@@ -26,7 +39,10 @@ p_gamma1 =
         p |> Bz(boost_gamma(p_pi0)) |> Ry(acos(Omega.cosθ)) |> Rz(Omega.ϕ)
     end
 
-# Photon 2 restores four-momentum: `p_gamma1 + p_gamma2 ≈ p_pi0`.
+# ## Photon 2 from momentum conservation
+#
+# In the lab, $\;p_{\pi^0}^\mu = p_{\gamma_1}^\mu + p_{\gamma_2}^\mu\;$, so $p_{\gamma_2} = p_{\pi^0} - p_{\gamma_1}$.
+# Both photons should remain light-like ($m^2 \approx 0$), and the sum should reproduce the parent.
 
 p_gamma2 = p_pi0 - p_gamma1
 
@@ -35,6 +51,8 @@ p_gamma2 = p_pi0 - p_gamma1
 @test mass(p_gamma1 + p_gamma2) ≈ mass(p_pi0)
 @test p_gamma1 + p_gamma2 ≈ p_pi0
 
-# ## Quick inspection
+# ## Inspect components
+#
+# Components are $(p_x, p_y, p_z, E)$; the slight mismatch in $m^2$ is at the level of floating-point error after boosts.
 
 (collect(p_pi0), collect(p_gamma1), collect(p_gamma2))

--- a/literate/tutorials/transformations.jl
+++ b/literate/tutorials/transformations.jl
@@ -1,0 +1,81 @@
+# # Lorentz transformations
+#
+# Changing reference frame means a Lorentz transformation on $p^\mu$.
+# This package implements **active** transformations: the **frame stays fixed** and the four-momentum is rotated or boosted.
+# That matches the usual HEP habit of “rotating the vector into the $z$ axis” before a longitudinal boost.
+#
+# All transforms preserve $m^2 = E^2 - |\vec{p}|^2$ (numerically, up to round-off).
+
+using FourVectors
+using Test
+
+p = FourVector(0.5, 0.5, 0.5; M = 1.0)
+
+# ## Spatial rotations (`Rx`, `Ry`, `Rz`)
+#
+# Rotations act on $(p_x, p_y, p_z)$ only; **$E$ is unchanged** (orthogonal transformation of the spatial part).
+# Angles are in radians, right-handed, about the lab axes:
+#
+# - **`Rx(p, α)`** — rotation about $x$
+# - **`Ry(p, θ)`** — rotation about $y$ (often used to bring $\vec{p}$ into the $x$–$z$ plane)
+# - **`Rz(p, φ)`** — rotation about $z$ (azimuthal alignment)
+#
+# Composing with the opposite angle returns the original momentum:
+
+α = 0.4
+@test Rx(Rx(p, α), -α) ≈ p
+@test Ry(Ry(p, α), -α) ≈ p
+@test Rz(Rz(p, α), -α) ≈ p
+
+p_ry = Ry(p, π / 4)
+
+# ## Longitudinal boost (`Bz`)
+#
+# **`Bz(p, γ)`** applies a boost along the lab **$z$** axis with Lorentz factor $\gamma$.
+# Use **`boost_gamma(p)`** (from LorentzVectorBase) when you need the $\gamma$ of an existing four-momentum.
+#
+# Sign convention: **negative $\gamma$** reverses the boost direction ($\beta \to -\beta$ at fixed $|\gamma|$).
+# This is handy when chaining “boost to lab” and “boost back to rest” without recomputing $\beta$.
+
+γ = 2.5
+@test Bz(Bz(p, γ), -γ) ≈ p
+
+p_boosted = Bz(p, γ)
+
+# ## Chaining transforms (`|>`)
+#
+# `Rx(α)`, `Ry(θ)`, `Rz(φ)`, and `Bz(γ)` can be partially applied to obtain unary maps,
+# which compose cleanly in pipelines — the same pattern as in the π⁰ decay tutorial.
+
+p_pipeline = p |> Ry(π / 6) |> Rz(0.2) |> Bz(1.5)
+@test p_pipeline isa FourVector
+
+# ## `rotate_to_plane` — align a reference direction
+#
+# **`rotate_to_plane(p, which_z, which_xplus)`** builds the rotation that:
+#
+# 1. Rotates the spatial direction of **`which_z`** onto lab **$+\hat{z}$** (`Ry`, then `Rz`), and
+# 2. Rotates about $z$ so **`which_xplus`** lies in the $x$–$z$ plane with $p_x \ge 0$.
+#
+# Only the **directions** of the reference four-vectors matter (masses are ignored for the rotation axes).
+# Use this when you want a standard frame where a beam or parent defines $z$ and a second vector fixes the $x$–$z$ plane.
+
+which_z = FourVector(0.0, 0.0, 1.0; M = 2.0)
+which_xplus = FourVector(1.0, 1.0, 0.0; M = 0.0)
+
+p_plane = rotate_to_plane(p, which_z, which_xplus)
+@test p_plane.py ≈ 0.0 atol = 1e-10
+@test p_plane.px ≥ 0.0
+
+# ## `transform_to_cmf` — go to another particle’s rest frame
+#
+# **`transform_to_cmf(p, which_cmf)`** transforms **`p`** into the rest frame of **`which_cmf`**:
+# rotate `which_cmf` onto $+\hat{z}$, then boost along $z$ with $\gamma = \gamma(\text{which\_cmf})$ so that `which_cmf` has zero spatial momentum.
+#
+# This is the frame where the total momentum of a two-body system is zero when `which_cmf` is chosen as one of the participants or as the total four-momentum.
+
+beam = FourVector(1.0, 0.0, 0.0; E = 2.0)
+p_cmf = transform_to_cmf(p, beam)
+@test p_cmf isa FourVector
+
+(collect(p), collect(p_ry), collect(p_boosted), collect(p_plane), collect(p_cmf))

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -31,7 +31,8 @@ LorentzVectorBase.py(mom::FourVector) = getfield(mom, :py)
 LorentzVectorBase.pz(mom::FourVector) = getfield(mom, :pz)
 LorentzVectorBase.E(mom::FourVector) = getfield(mom, :E)
 
-LinearAlgebra.dot(p1::FourVector, p2::FourVector) = p1.E * p2.E - dot(p1.P, p2.P)
+LinearAlgebra.dot(p1::FourVector, p2::FourVector) =
+    p1.E * p2.E - (p1.px * p2.px + p1.py * p2.py + p1.pz * p2.pz)
 
 """
     spherical_coordinates(p)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,2 +1,3 @@
 [deps]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/test-creation-and-interface.jl
+++ b/test/test-creation-and-interface.jl
@@ -1,4 +1,5 @@
 using FourVectors
+using LinearAlgebra
 using Test
 
 p = FourVector(1.0, 2.0, 3.0; E = 4.0)
@@ -38,4 +39,5 @@ end
     @test Ω.cosθ ≈ cos_theta(p)
     @test Ω.ϕ ≈ azimuthal_angle(p)
     @test propertynames(Ω) === (:cosθ, :ϕ)
+    @test dot(p, p) ≈ mass2(p)
 end


### PR DESCRIPTION
## Summary

- Add three Literate tutorials aimed at HEP users: creating/accessing four-momenta (metric, on-shell construction, accessors and aliases), algebra (`+`, `-`, scalar `*`, Minkowski `dot`), and Lorentz transforms (active rotations/boosts, `rotate_to_plane`, `transform_to_cmf`).
- Expand the existing π⁰ → γγ example with clearer physics narrative (conservation, light-like proxy, boost/rotation chain).
- Wire all tutorials into Documenter home page and `docs/make.jl`; add `LorentzVectorBase` to the docs environment for alias examples.
- Fix `dot(::FourVector, ::FourVector)` to use spatial components (was calling non-existent `.P`); add regression test.

## Test plan

- [x] `Pkg.test()` passes locally
- [x] `julia --project=docs docs/make.jl` builds and executes all tutorial code blocks
- [ ] CI (tests + documentation workflow)


Made with [Cursor](https://cursor.com)